### PR TITLE
expr_eval should handle character expressions with length > 1

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -67,6 +67,9 @@ exprs_eval <- function(..., env = parent.frame()) {
   if (is.symbol(expr)) {
     expr <- rlang::eval_tidy(expr, env = env)
   }
+  if (is.call(expr)) {
+    expr <- eval(expr)
+  }
 
   if (is.character(expr)) {
     expr <- rlang::parse_exprs(expr)

--- a/tests/testthat/test-end-to-end.R
+++ b/tests/testthat/test-end-to-end.R
@@ -75,9 +75,12 @@ test_that("end to end run - code", {
 test_that("exp_before_benchmark longer than one (will be parsed as call) is converted", {
   withr::local_envvar(GITHUB_BASE_REF = "main", GITHUB_HEAD_REF = "main")
   local_package()
+  # call a function from a r base not on the search path to make sure it
+  # errors without library()
+  expect_error(arrow)
   out <- benchmark_run_ref(
-    expr_before_benchmark = c("library(styler)", "cache_deactivate()"),
-    main = "style_text('1+1')",
+    expr_before_benchmark = c("library(grid)", "library(stats)"),
+    main = "arrow()",
     n = 1
   )
   expect_s3_class(out, "tbl_df")
@@ -86,9 +89,12 @@ test_that("exp_before_benchmark longer than one (will be parsed as call) is conv
 test_that("main expression longer than one (will be parsed as call) is converted", {
   withr::local_envvar(GITHUB_BASE_REF = "main", GITHUB_HEAD_REF = "main")
   local_package()
+  # call a function from a r base not on the search path to make sure it
+  # errors without library()
+  expect_error(arrow)
   out <- benchmark_run_ref(
-    expr_before_benchmark = c("library(styler)"),
-    main = c("style_text('1+1')", "style_text('1+1')"),
+    expr_before_benchmark = c("library(grid)"),
+    main = c("arrow()", "arrow()"),
     n = 1
   )
   expect_s3_class(out, "tbl_df")

--- a/tests/testthat/test-end-to-end.R
+++ b/tests/testthat/test-end-to-end.R
@@ -53,7 +53,7 @@ test_that("end to end run - code", {
     )
   }
   bm <- benchmark_run_ref(
-    expr_before_benchmark = source('R/core.R'),
+    expr_before_benchmark = source("R/core.R"),
     bliblablup = f(),
     refs = branches,
     n = 2
@@ -70,4 +70,26 @@ test_that("end to end run - code", {
     out,
     glue::glue("bliblablup: .* -> .*\\[.*%, .*\\]")
   )
+})
+
+test_that("exp_before_benchmark longer than one (will be parsed as call) is converted", {
+  withr::local_envvar(GITHUB_BASE_REF = "main", GITHUB_HEAD_REF = "main")
+  local_package()
+  out <- benchmark_run_ref(
+    expr_before_benchmark = c("library(styler)", "cache_deactivate()"),
+    main = "style_text('1+1')",
+    n = 1
+  )
+  expect_s3_class(out, "tbl_df")
+})
+
+test_that("main expression longer than one (will be parsed as call) is converted", {
+  withr::local_envvar(GITHUB_BASE_REF = "main", GITHUB_HEAD_REF = "main")
+  local_package()
+  out <- benchmark_run_ref(
+    expr_before_benchmark = c("library(styler)"),
+    main = c("style_text('1+1')", "style_text('1+1')"),
+    n = 1
+  )
+  expect_s3_class(out, "tbl_df")
 })


### PR DESCRIPTION
@assignUser, #38 actually [broke code](https://github.com/r-lib/styler/pull/835) in {styler}. An unexpected case but fixed it (hopefully).