### PR TITLE
Use setup-r-dependencies in gha

### DIFF
--- a/inst/touchstone-receive.yaml
+++ b/inst/touchstone-receive.yaml
@@ -47,33 +47,17 @@ jobs:
           git branch $GITHUB_BASE_REF remotes/origin/$GITHUB_BASE_REF
       - name: Setup R
         uses: r-lib/actions/setup-r@master
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - name: Setup dependencies
+        uses: r-lib/actions/setup-r-dependencies@master
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-3-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-3-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
-        run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
-          sudo apt-get install libcurl4-openssl-dev libgit2-dev
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_github("lorenzwalthert/touchstone")
-          remotes::install_cran(c('ggplot2', 'dplyr'))
+          cache-version: 1
+          extra-packages: |
+            lorenzwalthert/touchstone
+            ggplot2
+            dplyr
+            gert
+      - name: Remove global installation
+        run: | 
           pkg <- basename(getwd())
           if (pkg %in% rownames(installed.packages())) {
             remove.packages(pkg)


### PR DESCRIPTION
Closes #50 

This works quite well and makes the yaml a lot cleaner. Also {pak} is very cool :D finally no more conflicts when updating dev packages on windows...

I tested the new action here: https://github.com/assignUser/simstudy/runs/3523820674#step:6:1