### PR TITLE
re-try install after failure but verbose

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -25,11 +25,14 @@ ref_install <- function(ref = "main",
       dependencies = install_dependencies,
       force = !cache_up_to_date(ref, path_pkg)
     )
-    install_missing_deps(path_pkg = path_pkg)
     withr::local_options(warn = 2)
     rlang::with_handlers(
-      install_local(quiet = TRUE),
+      {
+        install_missing_deps(path_pkg = path_pkg, quiet = TRUE)
+        install_local(quiet = TRUE)
+      },
       error = function(e) {
+        install_missing_deps(path_pkg = path_pkg, quiet = FALSE)
         install_local(quiet = FALSE)
       }
     )
@@ -134,6 +137,6 @@ cache_get <- function() {
 #' into the respective {touchstone} library. Prepend the local touchstone
 #' library to the library path with [local_touchstone_libpath()].
 #' @keywords internal
-install_missing_deps <- function(path_pkg) {
-  remotes::install_deps(pkgdir = path_pkg, upgrade = "always")
+install_missing_deps <- function(path_pkg, quiet = FALSE) {
+  remotes::install_deps(pkgdir = path_pkg, upgrade = "always", quiet = quiet)
 }

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -25,7 +25,7 @@ ref_install <- function(ref = "main",
       dependencies = install_dependencies,
       force = !cache_up_to_date(ref, path_pkg)
     )
-
+    install_missing_deps(path_pkg = path_pkg)
     withr::local_options(warn = 2)
     rlang::with_handlers(
       install_local(quiet = TRUE),
@@ -121,4 +121,19 @@ cache_update <- function(ref, path_pkg) {
 #' @keywords internal
 cache_get <- function() {
   getOption("touchstone.hash_source_package")
+}
+
+#' Install missing BASE dependencies
+#'
+#' If the HEAD branch removes dependencies (compared to BASE), installing the
+#' package from the BASE branch will fail due to missing dependencies, as
+#' dependencies were installed in the GitHub Action based on the `DESCRIPTION`
+#' of the HEAD branch. The simplest way to
+#' ensure all required dependencies are present (including specification of
+#' remotes) is by simply installing them
+#' into the respective {touchstone} library. Prepend the local touchstone
+#' library to the library path with [local_touchstone_libpath()].
+#' @keywords internal
+install_missing_deps <- function(path_pkg) {
+  remotes::install_deps(pkgdir = path_pkg, upgrade = "always")
 }

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -20,11 +20,18 @@ ref_install <- function(ref = "main",
   } else {
     local_touchstone_libpath(ref)
     libpath <- .libPaths()
-    withr::local_options(warn = 2)
-    remotes::install_local(path_pkg,
-      upgrade = "never", quiet = TRUE,
+    install_local <- purrr::partial(remotes::install_local, path_pkg,
+      upgrade = "never",
       dependencies = install_dependencies,
       force = !cache_up_to_date(ref, path_pkg)
+    )
+
+    withr::local_options(warn = 2)
+    rlang::with_handlers(
+      install_local(quiet = TRUE),
+      error = function(e) {
+        install_local(quiet = FALSE)
+      }
     )
     cache_update(ref, path_pkg)
     cli::cli_alert_success("Installed branch {.val {ref}} into {.path {libpath[1]}}.")


### PR DESCRIPTION
Had this problem recently in {styler} that installation failed [uninformatively](https://github.com/r-lib/styler/runs/4275541020?check_suite_focus=true). Turned out it was because my PR removed a few dependencies from description, then installation for the main branch failed. Probably need a mechanism to check if all dependencies from BASE branch are in HEAD branch and if not, install those ones also into the touchstone library of base branch.