### PR TITLE
Bump action version

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -15,3 +15,7 @@ The actions will always be compatible with the version of {touchstone} of the sa
 ```yaml
 - uses lorenzwalthert/touchstone/actions/receive@v0.0.1
 ```
+There is also the tag `v1` which will occasionally be moved forward for small changes but never for breaking changes. ****We recommend this version for pre-CRAN releases.***
+```yaml
+- uses lorenzwalthert/touchstone/actions/receive@v1
+```

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -17,7 +17,7 @@ inputs:
   touchstone_ref:
     description: 'Which branch or tag of {touchstone} should be used. Mainly for debugging.'
     required: true
-    default: '@main'
+    default: '@v1'
     
 runs:
   using: "composite"

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -78,6 +78,7 @@ packagemanager
 pak
 pkgapi
 pkgdown
+pre
 prepending
 PRs
 purrr

--- a/inst/touchstone-comment.yaml
+++ b/inst/touchstone-comment.yaml
@@ -17,6 +17,6 @@ jobs:
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: lorenzwalthert/touchstone/actions/comment@main
+      - uses: lorenzwalthert/touchstone/actions/comment@v1
         with: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/inst/touchstone-receive.yaml
+++ b/inst/touchstone-receive.yaml
@@ -39,7 +39,7 @@ jobs:
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: lorenzwalthert/touchstone/actions/receive@main
+      - uses: lorenzwalthert/touchstone/actions/receive@v1
         with:
           cache-version: 1
           benchmarking_repo: ${{ matrix.config.benchmarking_repo }}


### PR DESCRIPTION
I created a v1 tag and added it to the `.yaml`s so people testing can use a stable version and not be disrupted