### PR TITLE
Fail safe comment

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -39,9 +39,12 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+        # desc gh version fixes a bug in create_package
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            github::r-lib/desc@main
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/lorenzwalthert/touchstone/issues
 Imports: 
     bench,
     callr,
-    cli,
+    cli (>= 3.0.1),
     fs,
     gert,
     magrittr,
@@ -43,6 +43,8 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     usethis
+Remotes: 
+    r-lib/mockery
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/actions/README.md
+++ b/actions/README.md
@@ -10,6 +10,7 @@ This folder contains the [Github Actions](https://github.com/features/actions) u
   * Comments the results on the PR that originated the workflow run. 
   * Has read & write access.
   * Started automatically when receive job finishes.
+  * Will create an additional commit status to the PR check suite. 
   
 The actions will always be compatible with the version of {touchstone} of the same git ref, so we recommend using the same tag for both {touchstone} and the actions, e.g. with {touchstone} v0.0.1:
 ```yaml

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -58,7 +58,7 @@ runs:
             state = 'failure'
             description = 'Commenting failed!'
             if(any_failed) {
-              url = "https://github.com/${{github.repository}}/actions/" + 
+              url = "https://github.com/${{github.repository}}/actions/runs/" + 
                     "${{ github.run_id }}"
             }
           }

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -32,20 +32,19 @@ runs:
       shell: bash
     - name: 'Comment on PR'
       id: 'comment'
-      run: exit 1
-      # uses: actions/github-script@v3
-      # with:
-      #   github-token: ${{ inputs.GITHUB_TOKEN }}
-      #   script: |
-      #     var fs = require('fs');
-      #     var issue_number = Number(fs.readFileSync('./NR'));
-      #     var body = fs.readFileSync('./info.txt').toString();
-      #     await github.issues.createComment({
-      #       owner: context.repo.owner,
-      #       repo: context.repo.repo,
-      #       issue_number: issue_number,
-      #       body: body
-      #     });
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ inputs.GITHUB_TOKEN }}
+        script: |
+          var fs = require('fs');
+          var issue_number = Number(fs.readFileSync('./NR'));
+          var body = fs.readFileSync('./info.txt').toString();
+          await github.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue_number,
+            body: body
+          });
     - uses: actions/github-script@v5
       if: always()
       with:
@@ -54,7 +53,7 @@ runs:
           let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
           let state = 'success'
           let description = 'Commenting succeeded!'
-
+          
           if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
             state = 'failure'
             description = 'Commenting failed!'

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -43,3 +43,30 @@ runs:
             issue_number: issue_number,
             body: body
           });
+    - uses: action/github-script@v5
+      if: always()
+      with:
+        script: |
+          let url = '${{ github.event.workflow_run.html_url }}'
+
+          if(${{ github.event.workflow_run.conclusion == 'failure' || failure() }} ) {
+            const state = 'failure'
+            const description = 'Commenting failed!'
+            if(${{ failure() }}) {
+              url = "https://github.com/${{github.repository}}/actions/" + 
+                    "${{ github.run_id }}"
+            }
+          } else {
+            const state = 'success'
+            const description = 'Commenting succeeded!'
+          }
+
+          github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: '${{ github.event.workflow_run.head_sha}}',
+            state: state,
+            target_url: url,
+            description: description,
+            context: 'touchstone comment'
+          })

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -51,17 +51,16 @@ runs:
         script: |
           let url = '${{ github.event.workflow_run.html_url }}'
           let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
-
+          let state = 'success'
+          let description = 'Commenting succeeded!'
+          
           if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
-            const state = 'failure'
-            const description = 'Commenting failed!'
+            state = 'failure'
+            description = 'Commenting failed!'
             if(any_failed) {
               url = "https://github.com/${{github.repository}}/actions/" + 
                     "${{ github.run_id }}"
             }
-          } else {
-            const state = 'success'
-            const description = 'Commenting succeeded!'
           }
 
           github.rest.repos.createCommitStatus({

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -8,6 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: 'Download artifact'
+      id: 'download'
       uses: actions/github-script@v3.1.0
       with:
         script: |
@@ -30,6 +31,7 @@ runs:
     - run: unzip pr.zip
       shell: bash
     - name: 'Comment on PR'
+      id: 'comment'
       uses: actions/github-script@v3
       with:
         github-token: ${{ inputs.GITHUB_TOKEN }}
@@ -48,11 +50,12 @@ runs:
       with:
         script: |
           let url = '${{ github.event.workflow_run.html_url }}'
-
-          if(${{ github.event.workflow_run.conclusion == 'failure' || failure() }} ) {
+          let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
+          
+          if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
             const state = 'failure'
             const description = 'Commenting failed!'
-            if(${{ failure() }}) {
+            if(any_failed) {
               url = "https://github.com/${{github.repository}}/actions/" + 
                     "${{ github.run_id }}"
             }

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -32,19 +32,20 @@ runs:
       shell: bash
     - name: 'Comment on PR'
       id: 'comment'
-      uses: actions/github-script@v3
-      with:
-        github-token: ${{ inputs.GITHUB_TOKEN }}
-        script: |
-          var fs = require('fs');
-          var issue_number = Number(fs.readFileSync('./NR'));
-          var body = fs.readFileSync('./info.txt').toString();
-          await github.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: issue_number,
-            body: body
-          });
+      run: exit 1
+      # uses: actions/github-script@v3
+      # with:
+      #   github-token: ${{ inputs.GITHUB_TOKEN }}
+      #   script: |
+      #     var fs = require('fs');
+      #     var issue_number = Number(fs.readFileSync('./NR'));
+      #     var body = fs.readFileSync('./info.txt').toString();
+      #     await github.issues.createComment({
+      #       owner: context.repo.owner,
+      #       repo: context.repo.repo,
+      #       issue_number: issue_number,
+      #       body: body
+      #     });
     - uses: actions/github-script@v5
       if: always()
       with:
@@ -53,7 +54,7 @@ runs:
           let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
           let state = 'success'
           let description = 'Commenting succeeded!'
-          
+
           if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
             state = 'failure'
             description = 'Commenting failed!'

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -45,13 +45,13 @@ runs:
             issue_number: issue_number,
             body: body
           });
-    - uses: action/github-script@v5
+    - uses: actions/github-script@v5
       if: always()
       with:
         script: |
           let url = '${{ github.event.workflow_run.html_url }}'
           let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
-          
+
           if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
             const state = 'failure'
             const description = 'Commenting failed!'

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -11,10 +11,12 @@ cli
 CMD
 config
 Config
+const
 cr
 cran
 cre
 createComment
+createCommitStatus
 datastore
 dcf
 de
@@ -105,6 +107,7 @@ runif
 saveRDS
 seealso
 sep
+sha
 SHA
 sideeffects
 sprintf

--- a/inst/touchstone-comment.yaml
+++ b/inst/touchstone-comment.yaml
@@ -14,8 +14,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
+      ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - uses: lorenzwalthert/touchstone/actions/comment@v1
         with: 

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -7,7 +7,7 @@
 
     Code
       activate()
-    Warning <warning>
+    Warning <rlang_warning>
       `activate()` is meant for interactive useonly, make sure 'script.R' works as intended!
 
 ---
@@ -26,7 +26,7 @@
 
     Code
       activate()
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22m[30m[47m`activate()`[49m[39m is meant for interactive useonly, make sure [34mscript.R[39m works as intended!
 
 ---
@@ -45,7 +45,7 @@
 
     Code
       activate()
-    Warning <warning>
+    Warning <rlang_warning>
       `activate()` is meant for interactive useonly, make sure 'script.R' works as intended!
 
 ---
@@ -64,7 +64,7 @@
 
     Code
       activate()
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22m[30m[47m`activate()`[49m[39m is meant for interactive useonly, make sure [34mscript.R[39m works as intended!
 
 ---


### PR DESCRIPTION
Closes #105 

This adds an additional commit status to the pr check suite even if the commenting itself fails. I also changed the wf file, that way the status is also added when the receive action fails but that is more cosmetic then anything because that will already create a failed commit status.

