### PR TITLE
Fix the PR number artifact when triggered from a comment.

### DIFF
--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -53,6 +53,7 @@ runs:
           }
 
           var pull = {
+            number: pr.number,
             head_repo: pr.head.repo.full_name,
             head_ref: pr.head.ref,
             is_fork: is_fork,
@@ -127,7 +128,7 @@ runs:
       shell: Rscript {0}
     - name: Uploading Results
       run: |
-        echo ${{ github.event.number }} > ./touchstone/pr-comment/NR
+        echo ${{ fromJSON(steps.get-pull.outputs.result).number }} > ./touchstone/pr-comment/NR
       shell: bash
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
The receive action was storing `github.event.number` as an artefact for the comment action to use. However, this field is only set for pull request events. If the workflow is configured to trigger on a comment, the event type is now `issue_comment` as the field is absent.

There is an equivalent field at `github.event.issue.number`, but that field is absent for PR events. The easiest way to get the number in a uniform and consistent way is to use the PR metadata we already have at the start of the action.