### PR TITLE
Use the head branch's touchstone script.

### DIFF
--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -82,13 +82,12 @@ runs:
       shell: bash
       run: |
         REMOTE=origin
-        ! git branch -D ${{ env.GITHUB_BASE_REF }}
         if ${{ fromJSON(steps.get-pull.outputs.result).is_fork }}; then
           git remote add touchstone_base ${{ fromJSON(steps.get-pull.outputs.result).base_git }}
           git fetch touchstone_base
           REMOTE=touchstone_base
         fi
-        git switch -c ${{ env.GITHUB_BASE_REF }} $REMOTE/${{ env.GITHUB_BASE_REF }}
+        git branch -f ${{ env.GITHUB_BASE_REF }} $REMOTE/${{ env.GITHUB_BASE_REF }}
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
     - name: Install dependencies


### PR DESCRIPTION
When setting up branches, we were switching from the head to the base branch. This implies that the benchmarking script being used is that of the base branch.

I believe it makes more sense to use the head branch's script, as when one adds a new benchmark to an existing script, you would want to see to results of it without having to merge that PR first.

This actually used to be the behaviour but was changed as part of #112. I cannot see any discussion about this change so I suspect it may have been unintentional.