### PR TITLE
Fix how the author association is looked up for PRs.

### DIFF
--- a/R/use.R
+++ b/R/use.R
@@ -166,10 +166,10 @@ use_touchstone_workflows <- function(overwrite = FALSE,
   if (is.null(command)) {
     trigger <- "\n  pull_request:"
     ward <- glue::glue(
-     "\n    if:\n",
-     "      true ",
-     limit,
-     .trim = FALSE
+      "\n    if:\n",
+      "      true ",
+      limit,
+      .trim = FALSE
     )
   } else {
     # these have to be indented with 2 spaces per tab,

--- a/R/use.R
+++ b/R/use.R
@@ -139,13 +139,17 @@ use_touchstone_workflows <- function(overwrite = FALSE,
     system.file("touchstone-receive.yaml", package = "touchstone")
   )
 
-  trigger <- "\n  pull_request:"
-  ward <- ""
   force <- ifelse(force_upstream, "\n          force_upstream: true", "")
+
+  if (is.null(command)) {
+    author_association <- "github.event.pull_request.author_association"
+  } else {
+    author_association <- "github.event.comment.author_association"
+  }
 
   if (!is.null(limit_to)) {
     limit <- glue::glue_collapse(
-      glue::glue("        github.event.comment.author_association == '{limit_to}' "),
+      glue::glue("        {author_association} == '{limit_to}' "),
       sep = "||\n"
     )
     limit <- glue::glue(
@@ -158,14 +162,16 @@ use_touchstone_workflows <- function(overwrite = FALSE,
     limit <- ""
   }
 
-  ward <- glue::glue(
-    "\n    if:\n",
-    "      true ",
-    limit,
-    .trim = FALSE
-  )
 
-  if (!is.null(command)) {
+  if (is.null(command)) {
+    trigger <- "\n  pull_request:"
+    ward <- glue::glue(
+     "\n    if:\n",
+     "      true ",
+     limit,
+     .trim = FALSE
+    )
+  } else {
     # these have to be indented with 2 spaces per tab,
     # yaml does not allow tabs
     trigger <- glue::glue(

--- a/tests/testthat/_snaps/use/receive_default.yml
+++ b/tests/testthat/_snaps/use/receive_default.yml
@@ -13,9 +13,9 @@ jobs:
     if:
       true &&
       (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR' 
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR' 
       )
     outputs:
       config: ${{ steps.read_touchstone_config.outputs.config }}

--- a/tests/testthat/_snaps/use/receive_limit.yml
+++ b/tests/testthat/_snaps/use/receive_limit.yml
@@ -13,7 +13,7 @@ jobs:
     if:
       true &&
       (
-        github.event.comment.author_association == 'OWNER' 
+        github.event.pull_request.author_association == 'OWNER' 
       )
     outputs:
       config: ${{ steps.read_touchstone_config.outputs.config }}


### PR DESCRIPTION
The use_touchstone_workflows was generating code that used the `github.event.comment.author_association` regardless of the trigger type. However this does not work for pull_request triggers, meaning the if condition would always fail to evaluate and the workflow never ran. This commit fixes that by using the correct field name.