### PR TITLE
Upload raw benchmark results as an artifact.

### DIFF
--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -128,6 +128,7 @@ runs:
     - name: Uploading Results
       run: |
         echo ${{ fromJSON(steps.get-pull.outputs.result).number }} > ./touchstone/pr-comment/NR
+        cat touchstone/pr-comment/info.txt
       shell: bash
     - uses: actions/upload-artifact@v2
       with:
@@ -136,13 +137,7 @@ runs:
     - uses: actions/upload-artifact@v2
       with:
         name: results
-        path: touchstone/pr-comment
-    - uses: actions/download-artifact@v2
-      with:
-        name: results
-    - name: comment PR
-      run: cat touchstone/pr-comment/info.txt
-      shell: bash
+        path: touchstone/records/
     - uses: actions/upload-artifact@v2
       with:
         name: pr


### PR DESCRIPTION
The raw benchmark results weren't available anywhere. Exposing them as an artifact is convenient for investigation and to customize the rendering and visualization after the fact.

The receive action was uploading the PR comment as an artifact twice, once named "pr" and once named "results". Only the former is used by the comment action. Given the redundancy I assume this must have been a mistake. The "results" artifact now contains the raw benchmarking numbers instead.

I've also removed a spurious download-artifact step, which was downloading the same files that had just been uploaded, for no apparent reason.