### PR TITLE
Don't make `bench::mark` check results.

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -34,7 +34,7 @@ benchmark_run_iteration <- function(expr_before_benchmark,
         withr::local_namespace("touchstone")
         withr::local_options(asset_dirs)
         eval(expr_before_benchmark)
-        benchmark <- bench::mark(eval(dots[[1]]), memory = FALSE, iterations = 1)
+        benchmark <- bench::mark(eval(dots[[1]]), check = FALSE, memory = FALSE, iterations = 1)
         benchmark_write(benchmark, names(dots), branch = branch, block = block, iteration = iteration)
       },
       args = append(args, lst(iteration)),


### PR DESCRIPTION
By default, the `bench::mark` function used by touchstone runs one additional iteration of the benchmark, whose result it keeps and uses to check for equivalence in behaviour of the given expressions.

This feature doesn't make sense in the context of touchstone, where only one version is being benchmarked at a time. Moreover, given that `bench::mark` is always called to run a single iteration, this behaviour effectively doubles the number of iterations being run but without keeping the results from these extra runs, which was wastefuly doubling the time taking to run the action.

We can avoid this behaviour by passing `check = FALSE` as an argument to the function.