### PR TITLE
Allow touchstone package to be installed from custom source.

### DIFF
--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -18,10 +18,10 @@ inputs:
     description: 'Integer to use as cache version. Increment to use new cache.'
     required: true
     default: 1
-  touchstone_ref:
-    description: 'Which branch or tag of {touchstone} should be used. Mainly for debugging.'
+  touchstone_package:
+    description: 'Which package of {touchstone} should be used. Mainly for debugging.'
     required: true
-    default: '@v1'
+    default: 'github::lorenzwalthert/touchstone@v1'
   extra-packages:
     description: 'Any extra packages that should be installed.'
 
@@ -100,7 +100,7 @@ runs:
           any::dplyr
           any::gert
           any::glue
-          github::lorenzwalthert/touchstone${{ inputs.touchstone_ref}}
+          ${{ inputs.touchstone_package }}
           ${{ inputs.extra-packages }}
     - name: Remove global installation
       run: |

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -21,7 +21,11 @@ inputs:
   touchstone_package:
     description: 'Which package of {touchstone} should be used. Mainly for debugging.'
     required: true
-    default: 'github::lorenzwalthert/touchstone@v1'
+    default: 'github::lorenzwalthert/touchstone'
+  touchstone_ref:
+    description: 'Which branch or tag of {touchstone} should be used. This will be appended to the touchstone_package option. Mainly for debugging.'
+    required: true
+    default: '@v1'
   extra-packages:
     description: 'Any extra packages that should be installed.'
 
@@ -100,7 +104,7 @@ runs:
           any::dplyr
           any::gert
           any::glue
-          ${{ inputs.touchstone_package }}
+          ${{ inputs.touchstone_package }}${{ inputs.touchstone_ref }}
           ${{ inputs.extra-packages }}
     - name: Remove global installation
       run: |


### PR DESCRIPTION
Instead of allowing the user to select a particular branch of the `lorenzwalthert/touchstone` repository, allow an arbitrary package to be used instead. This gives greater flexibility for development in forks of the repository.