### PR TITLE
Update upload artifact and add option for extra repositories

### DIFF
--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -12,7 +12,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: pr
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.GITHUB_TOKEN }}
         repository: context.repo.repo
         run-id: ${{github.event.workflow_run.id }}
     - run: unzip pr.zip

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -15,8 +15,6 @@ runs:
         github-token: ${{ inputs.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
         run-id: ${{github.event.workflow_run.id }}
-    - run: unzip pr.zip
-      shell: bash
     - name: 'Comment on PR'
       id: 'comment'
       uses: actions/github-script@v3

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -9,25 +9,12 @@ runs:
   steps:
     - name: 'Download artifact'
       id: 'download'
-      uses: actions/github-script@v3.1.0
+      uses: actions/download-artifact@v4
       with:
-        script: |
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             run_id: ${{github.event.workflow_run.id }},
-          });
-          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == "pr"
-          })[0];
-          var download = await github.actions.downloadArtifact({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             artifact_id: matchArtifact.id,
-             archive_format: 'zip',
-          });
-          var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+        name: pr
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: context.repo.repo
+        run-id: ${{github.event.workflow_run.id }}
     - run: unzip pr.zip
       shell: bash
     - name: 'Comment on PR'

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -13,7 +13,7 @@ runs:
       with:
         name: pr
         github-token: ${{ inputs.GITHUB_TOKEN }}
-        repository: context.repo.repo
+        repository: ${{ github.repository }}
         run-id: ${{github.event.workflow_run.id }}
     - run: unzip pr.zip
       shell: bash

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -24,6 +24,9 @@ inputs:
     default: '@v1'
   extra-packages:
     description: 'Any extra packages that should be installed.'
+  extra-repositories:
+    description: 'Specify extra repositories to be passed to setup-r'
+    default: ''
 
 runs:
   using: "composite"
@@ -91,6 +94,8 @@ runs:
         git branch -f ${{ env.GITHUB_BASE_REF }} $REMOTE/${{ env.GITHUB_BASE_REF }}
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
+      extra-repositories: ${{ inputs.extra-repositories }}
+
     - name: Install dependencies
       uses: r-lib/actions/setup-r-dependencies@v2
       with:

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -130,15 +130,15 @@ runs:
         echo ${{ fromJSON(steps.get-pull.outputs.result).number }} > ./touchstone/pr-comment/NR
         cat touchstone/pr-comment/info.txt
       shell: bash
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: visual-benchmarks
         path: touchstone/plots/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: results
         path: touchstone/records/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: pr
         path: touchstone/pr-comment/

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -94,7 +94,8 @@ runs:
         git branch -f ${{ env.GITHUB_BASE_REF }} $REMOTE/${{ env.GITHUB_BASE_REF }}
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
-      extra-repositories: ${{ inputs.extra-repositories }}
+      with:
+        extra-repositories: ${{ inputs.extra-repositories }}
 
     - name: Install dependencies
       uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
As the title, this PR updates the version of upload artifacts which was throwing a depreciation error for me. 

I have also added a pass-through of the `extra_repositories` option for `setup-r` as our use case needs this in order to install our dependencies (I can split this off into another PR if desired).

I have this running here from my fork and it looks like everything is now working as expected: https://github.com/epinowcast/primarycensoreddist/actions/runs/10906920699?pr=79

The non-forked version is failing here with the depreciation note I mentioned: https://github.com/epinowcast/epinowcast/actions/runs/10839748687?pr=528

Thanks a lot for keeping this ticking over. We find it very useful for a lot of our work.