### PR TITLE
Fix comment workflow

### DIFF
--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -24,7 +24,7 @@ runs:
           var fs = require('fs');
           var issue_number = Number(fs.readFileSync('./NR'));
           var body = fs.readFileSync('./info.txt').toString();
-          await github.issues.createComment({
+          await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: issue_number,


### PR DESCRIPTION
There was a change in namespace at some point that needs to be added. After this PR we need to move the tag forward as well.

Fixes #148 