### PR TITLE
support branch names with special characters

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -86,12 +86,14 @@ benchmark_ls <- function(name = "") {
   dirs <- fs::dir_ls(path, type = "file")
   new_benchmark_ls_tibble(
     name = fs::path_file(fs::path_dir(dirs)),
-    branch = fs::path_file(dirs)
+    branch = branch_decode(fs::path_file(dirs))
   )
 }
 
 path_record <- function(name = "", branch = "") {
-  as.character(fs::path(dir_touchstone(), "records", name, branch))
+  as.character(
+    fs::path(dir_touchstone(), "records", name, branch_encode(branch))
+  )
 }
 
 benchmark_read_impl <- function(path) {

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -78,7 +78,7 @@ branch_install <- function(branches = c(
 
 
 libpath_touchstone <- function(branch) {
-  fs::path(dir_touchstone(), "lib", branch)
+  fs::path(dir_touchstone(), "lib", branch_encode(branch))
 }
 
 #' When did the package sources change last?

--- a/R/utils.R
+++ b/R/utils.R
@@ -394,22 +394,41 @@ envvar_true <- function(var) {
 
 #' Encode branch name for use in file paths
 #'
-#' Replaces forward slashes with a safe placeholder to allow branch names
-#' like "feature/new-feature" to be used as directory names.
+#' Replaces characters that are problematic for file systems with URL-style
+#' percent encoding. This allows branch names like "feature/new-feature" or
+#' "fix<issue>" to be used as directory names across all platforms.
 #' @param branch A character vector of branch names.
 #' @return The encoded branch name(s) safe for use in file paths.
 #' @keywords internal
 branch_encode <- function(branch) {
-  gsub("/", "%2F", branch, fixed = TRUE)
+
+  # Order matters: encode % first to avoid double-encoding
+
+  branch <- gsub("%", "%25", branch, fixed = TRUE)
+  branch <- gsub("/", "%2F", branch, fixed = TRUE)
+  branch <- gsub(":", "%3A", branch, fixed = TRUE)
+  branch <- gsub("<", "%3C", branch, fixed = TRUE)
+  branch <- gsub(">", "%3E", branch, fixed = TRUE)
+  branch <- gsub("\"", "%22", branch, fixed = TRUE)
+  branch <- gsub("|", "%7C", branch, fixed = TRUE)
+  branch
 }
 
 #' Decode branch name from file path
 #'
-#' Restores the original branch name by converting the placeholder back to
-#' forward slashes.
+#' Restores the original branch name by converting percent-encoded characters
+#' back to their original form.
 #' @param branch A character vector of encoded branch names.
 #' @return The decoded branch name(s).
 #' @keywords internal
 branch_decode <- function(branch) {
-  gsub("%2F", "/", branch, fixed = TRUE)
+  # Order matters: decode % last to avoid issues with encoded %
+  branch <- gsub("%2F", "/", branch, fixed = TRUE)
+  branch <- gsub("%3A", ":", branch, fixed = TRUE)
+  branch <- gsub("%3C", "<", branch, fixed = TRUE)
+  branch <- gsub("%3E", ">", branch, fixed = TRUE)
+  branch <- gsub("%22", "\"", branch, fixed = TRUE)
+  branch <- gsub("%7C", "|", branch, fixed = TRUE)
+  branch <- gsub("%25", "%", branch, fixed = TRUE)
+  branch
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -391,3 +391,25 @@ envvar_true <- function(var) {
   stopifnot(is.character(var))
   as.logical(toupper(Sys.getenv(var))) %|% FALSE
 }
+
+#' Encode branch name for use in file paths
+#'
+#' Replaces forward slashes with a safe placeholder to allow branch names
+#' like "feature/new-feature" to be used as directory names.
+#' @param branch A character vector of branch names.
+#' @return The encoded branch name(s) safe for use in file paths.
+#' @keywords internal
+branch_encode <- function(branch) {
+  gsub("/", "%2F", branch, fixed = TRUE)
+}
+
+#' Decode branch name from file path
+#'
+#' Restores the original branch name by converting the placeholder back to
+#' forward slashes.
+#' @param branch A character vector of encoded branch names.
+#' @return The decoded branch name(s).
+#' @keywords internal
+branch_decode <- function(branch) {
+  gsub("%2F", "/", branch, fixed = TRUE)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -401,7 +401,6 @@ envvar_true <- function(var) {
 #' @return The encoded branch name(s) safe for use in file paths.
 #' @keywords internal
 branch_encode <- function(branch) {
-
   # Order matters: encode % first to avoid double-encoding
 
   branch <- gsub("%", "%25", branch, fixed = TRUE)

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -29,32 +29,18 @@ test_that("fails on corrupt benchmark", {
   )
 })
 
-test_that("can handle branch names with slashes", {
+test_that("can handle branch names with filesystem-unsafe characters", {
   local_clean_touchstone()
-  branch <- "feature/new-feature"
+  # Test slashes, colons, and other problematic characters
+  branches <- c("feature/new", "user/deep/branch", "fix:bug", "test<issue>")
   atomic <- bench::mark(1 + 1, iterations = 1)
-  expect_silent(
-    benchmark_write(atomic, name = "x1", branch = branch)
-  )
-  bm <- benchmark_read(branch, name = "x1")
-  expect_equal(unique(bm$branch), branch)
-  expect_equal(
-    benchmark_ls(name = "x1"),
-    tibble::tibble(name = "x1", branch = branch)
-  )
-})
-
-test_that("can handle branch names with multiple slashes", {
-  local_clean_touchstone()
-  branch <- "user/feature/deep-branch"
-  atomic <- bench::mark(1 + 1, iterations = 1)
-  expect_silent(
-    benchmark_write(atomic, name = "x1", branch = branch)
-  )
-  bm <- benchmark_read(branch, name = "x1")
-  expect_equal(unique(bm$branch), branch)
-  expect_equal(
-    benchmark_ls(name = "x1"),
-    tibble::tibble(name = "x1", branch = branch)
-  )
+  for (branch in branches) {
+    expect_silent(
+      benchmark_write(atomic, name = "x1", branch = branch)
+    )
+    bm <- benchmark_read(branch, name = "x1")
+    expect_equal(unique(bm$branch), branch)
+  }
+  result <- benchmark_ls(name = "x1")
+  expect_equal(sort(result$branch), sort(branches))
 })

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -28,3 +28,33 @@ test_that("fails on corrupt benchmark", {
     "only supports"
   )
 })
+
+test_that("can handle branch names with slashes", {
+  local_clean_touchstone()
+  branch <- "feature/new-feature"
+  atomic <- bench::mark(1 + 1, iterations = 1)
+  expect_silent(
+    benchmark_write(atomic, name = "x1", branch = branch)
+  )
+  bm <- benchmark_read(branch, name = "x1")
+  expect_equal(unique(bm$branch), branch)
+  expect_equal(
+    benchmark_ls(name = "x1"),
+    tibble::tibble(name = "x1", branch = branch)
+  )
+})
+
+test_that("can handle branch names with multiple slashes", {
+  local_clean_touchstone()
+  branch <- "user/feature/deep-branch"
+  atomic <- bench::mark(1 + 1, iterations = 1)
+  expect_silent(
+    benchmark_write(atomic, name = "x1", branch = branch)
+  )
+  bm <- benchmark_read(branch, name = "x1")
+  expect_equal(unique(bm$branch), branch)
+  expect_equal(
+    benchmark_ls(name = "x1"),
+    tibble::tibble(name = "x1", branch = branch)
+  )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -236,3 +236,23 @@ test_that("can assert no global installation", {
   mockery::stub(assert_no_global_installation, "is_installed", list(installed = TRUE, name = "pkg"))
   expect_error(assert_no_global_installation(), "can be found on a non-touchstone library path.")
 })
+
+test_that("branch_encode handles slashes", {
+  expect_equal(branch_encode("main"), "main")
+  expect_equal(branch_encode("feature/new"), "feature%2Fnew")
+  expect_equal(branch_encode("user/feature/deep"), "user%2Ffeature%2Fdeep")
+  expect_equal(branch_encode(""), "")
+})
+
+test_that("branch_decode restores slashes", {
+  expect_equal(branch_decode("main"), "main")
+  expect_equal(branch_decode("feature%2Fnew"), "feature/new")
+  expect_equal(branch_decode("user%2Ffeature%2Fdeep"), "user/feature/deep")
+  expect_equal(branch_decode(""), "")
+})
+
+test_that("branch_encode and branch_decode are inverses", {
+  branches <- c("main", "feature/new", "user/deep/branch", "no-slash")
+  expect_equal(branch_decode(branch_encode(branches)), branches)
+})
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -237,22 +237,38 @@ test_that("can assert no global installation", {
   expect_error(assert_no_global_installation(), "can be found on a non-touchstone library path.")
 })
 
-test_that("branch_encode handles slashes", {
+test_that("branch_encode handles filesystem-unsafe characters", {
   expect_equal(branch_encode("main"), "main")
   expect_equal(branch_encode("feature/new"), "feature%2Fnew")
-  expect_equal(branch_encode("user/feature/deep"), "user%2Ffeature%2Fdeep")
+  expect_equal(branch_encode("fix:bug"), "fix%3Abug")
+  expect_equal(branch_encode("test<>issue"), "test%3C%3Eissue")
+  expect_equal(branch_encode("pipe|test"), "pipe%7Ctest")
+  expect_equal(branch_encode("has%percent"), "has%25percent")
   expect_equal(branch_encode(""), "")
 })
 
-test_that("branch_decode restores slashes", {
+test_that("branch_decode restores original characters", {
   expect_equal(branch_decode("main"), "main")
   expect_equal(branch_decode("feature%2Fnew"), "feature/new")
-  expect_equal(branch_decode("user%2Ffeature%2Fdeep"), "user/feature/deep")
+  expect_equal(branch_decode("fix%3Abug"), "fix:bug")
+  expect_equal(branch_decode("test%3C%3Eissue"), "test<>issue")
+  expect_equal(branch_decode("has%25percent"), "has%percent")
   expect_equal(branch_decode(""), "")
 })
 
 test_that("branch_encode and branch_decode are inverses", {
-  branches <- c("main", "feature/new", "user/deep/branch", "no-slash")
+  # Test all problematic characters: / : < > " | %
+  branches <- c(
+    "main",
+    "feature/new",
+    "user/deep/branch",
+    "fix:bug",
+    "test<issue>",
+    "with\"quotes",
+    "pipe|char",
+    "has%percent",
+    "all/chars:<>|\"%mixed"
+  )
   expect_equal(branch_decode(branch_encode(branches)), branches)
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -271,4 +271,3 @@ test_that("branch_encode and branch_decode are inverses", {
   )
   expect_equal(branch_decode(branch_encode(branches)), branches)
 })
-


### PR DESCRIPTION
Closes #125

- Fixes branch names containing forward slashes (e.g., `feature/new-feature`) not being recognized by `benchmark_ls()` and other functions
- Encodes all filesystem-unsafe characters (`/`, `:`, `<`, `>`, `"`, `|`, `%`) using URL-style percent encoding for cross-platform compatibility (Windows, macOS, Linux)
- Adds `branch_encode()` and `branch_decode()` helpers to safely use branch names in file paths
- Also adds tests of all of these