### PR TITLE
Use R version from config file

### DIFF
--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -31,6 +31,10 @@ inputs:
   extra-repositories:
     description: 'Specify extra repositories to be passed to setup-r'
     default: ''
+  r-version:
+    description: 'R version to use.'
+    required: false
+    default: 'release'
 
 runs:
   using: "composite"
@@ -99,6 +103,7 @@ runs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
+        r-version: ${{ inputs.r-version }}
         extra-repositories: ${{ inputs.extra-repositories }}
 
     - name: Install dependencies

--- a/inst/touchstone-receive.yaml
+++ b/inst/touchstone-receive.yaml
@@ -48,3 +48,4 @@ jobs:
           benchmarking_repo: ${{ matrix.config.benchmarking_repo }}
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
           benchmarking_path: ${{ matrix.config.benchmarking_path }} #- force
+          r-version: ${{ matrix.config.r }}

--- a/tests/testthat/_snaps/use/receive_all.yml
+++ b/tests/testthat/_snaps/use/receive_all.yml
@@ -56,3 +56,4 @@ jobs:
           benchmarking_repo: ${{ matrix.config.benchmarking_repo }}
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
           benchmarking_path: ${{ matrix.config.benchmarking_path }} 
+          r-version: ${{ matrix.config.r }}

--- a/tests/testthat/_snaps/use/receive_command.yml
+++ b/tests/testthat/_snaps/use/receive_command.yml
@@ -59,3 +59,4 @@ jobs:
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
           benchmarking_path: ${{ matrix.config.benchmarking_path }} 
           force_upstream: true
+          r-version: ${{ matrix.config.r }}

--- a/tests/testthat/_snaps/use/receive_default.yml
+++ b/tests/testthat/_snaps/use/receive_default.yml
@@ -57,3 +57,4 @@ jobs:
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
           benchmarking_path: ${{ matrix.config.benchmarking_path }} 
           force_upstream: true
+          r-version: ${{ matrix.config.r }}

--- a/tests/testthat/_snaps/use/receive_limit.yml
+++ b/tests/testthat/_snaps/use/receive_limit.yml
@@ -55,3 +55,4 @@ jobs:
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
           benchmarking_path: ${{ matrix.config.benchmarking_path }} 
           force_upstream: true
+          r-version: ${{ matrix.config.r }}


### PR DESCRIPTION
I needed this to be able to run benchmarks on a feature currently in R devel.

It also aligns with expectations created by the presence of an `r` field in `touchstone/config.json`